### PR TITLE
Hierarchy on landing page

### DIFF
--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -24,7 +24,7 @@ Our APIs provide HTTP headers that you can use to pass this audit data to us.
 
 These headers can influence the processing of the API call, or support our prosecutions for tax or duty fraud.
 
-## Your legal obligations
+### Your legal obligations
 
 From 1 April 2019, regulation 2(2) of the <a href="http://www.legislation.gov.uk/uksi/2019/360/made">Delivery of Tax Information through Software (Ancillary Metadata) Regulations 2019 (S.I. 360/2019)</a> requires this by law.
 
@@ -44,6 +44,8 @@ We have published our <a href="/api-documentation/assets/content/documentation/3
 
 If you use or plan to use third-party software and libraries, for example an extension to an ERP system or a plugin to a spreadsheet application, make sure you can still access the header data you need to send to HMRC.
 
-## Security
+### Using third-party software and libraries
+
+If you use or plan to use third-party software and libraries, for example an extension to an ERP system or a plugin to a spreadsheet application, make sure you can still access the header data you need to send to HMRC. Security
 
 Transaction Monitoring (TxM) is a key security approach adopted in the UK and globally. Our approach is in line with National Cyber Security Centre (NCSC) and Cabinet Office <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/271268/GPG_53_Transaction_Monitoring_issue_1-1_April_2013.pdf">recommended guidance</a> and industry good practice.


### PR DESCRIPTION
Reduced 'Legal obligations' and 'security' to 3rd tier content (do not appear in navigation).