### PR TITLE
NOJIRA: Remove deprecated ga() function calls

### DIFF
--- a/source/connection-method/index.html.md.erb
+++ b/source/connection-method/index.html.md.erb
@@ -9,28 +9,28 @@ description: The data you need to send depends on your software architecture. Se
 
 The header data you need to send depends on your software architecture. We refer to your architecture as a connection method.
 
-Your connection method depends on <a href="#connecting-to-hmrc" onclick="ga('send', 'event', 'On Page Navigation', 'What you need to send', 'How your application connects');">how your application connects</a> to HMRC and your <a href="#originating-device" onclick="ga('send', 'event', 'On Page Navigation', 'What you need to send', 'Originating device');">originating device</a>. You might have more than 1 connection method.
+Your connection method depends on <a href="#connecting-to-hmrc">how your application connects</a> to HMRC and your <a href="#originating-device">originating device</a>. You might have more than 1 connection method.
 
 To find out what data you need to send, select the connection methods used by your application.
 
 ## Select your connection method
 
-<a href="desktop-app-direct/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Desktop application direct');">Desktop application direct</a><br>
+<a href="desktop-app-direct/">Desktop application direct</a><br>
 Your application is installed on a desktop connecting directly to HMRC. Desktops include computers and laptops.</p>
 
-<a href="desktop-app-via-server/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Desktop application via server');">Desktop application via server</a><br>
+<a href="desktop-app-via-server/">Desktop application via server</a><br>
 Your application is installed on a desktop connecting to HMRC through intermediary servers. Desktops include computers and laptops.
 
-<a href="web-app-via-server/"  onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Web application via server');">Web application via server</a><br>
+<a href="web-app-via-server/">Web application via server</a><br>
 Your application is web based, connecting to HMRC through intermediary servers.
 
-<a href="mobile-app-direct/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Mobile application direct');">Mobile application direct</a><br>
+<a href="mobile-app-direct/">Mobile application direct</a><br>
 Your application is installed on a mobile device connecting directly to HMRC. Mobile devices include phones and tablets.
 
-<a href="mobile-app-via-server/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Mobile application via server');">Mobile application via server</a><br>
+<a href="mobile-app-via-server/">Mobile application via server</a><br>
 Your application is installed on a mobile device connecting to HMRC through intermediary servers. Mobile devices include phones and tablets.
 
-<a href="batch-process-direct/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Batch process direct');">Batch process direct</a><br>
+<a href="batch-process-direct/">Batch process direct</a><br>
 Only select this for requests when your users do not initiate an action and your application uses batch processes, connecting directly to HMRC.
 
 
@@ -44,10 +44,10 @@ Only select this for requests when your users do not initiate an action and your
 
     <p>You can select other direct or other via server. We may ask you for more details.</p>
 
-  <p><a href="other-direct/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Other direct');">Other direct</a><br>
+  <p><a href="other-direct/">Other direct</a><br>
     Your application connects directly to HMRC but is not covered by the common architectures.</p>
 
-    <p><a href="other-via-server/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Other via server');">Other via server</a><br>
+    <p><a href="other-via-server/">Other via server</a><br>
     Your application connects to HMRC through intermediary servers but is not covered by the common architectures.</p>
   </div>
 </details>

--- a/source/getting-it-right/index.html.md.erb
+++ b/source/getting-it-right/index.html.md.erb
@@ -8,7 +8,7 @@ description: Check your application is sending data in the right format. Underst
 # Getting it right
 
 Version 3.1 issued 31 January 2022 <br/>
-<a href="../change-log/" onclick="ga('send', 'event', 'On Page Navigation', 'Getting it right', 'Check what has changed');">Check what has changed</a>
+<a href="../change-log/">Check what has changed</a>
 
 ## How we check data
 
@@ -48,9 +48,9 @@ Before you submit any header data, <a href="../test-api/#use-the-test-api">use t
 
 ## Send data in the correct format
 
-Header data contents must be submitted using the US-ASCII character set, with other characters <a href="https://tools.ietf.org/html/rfc3986#section-2.1" target="_blank" rel="noopener noreferrer" onclick="ga('send', 'event', 'On Page Navigation', 'Send data in the correct format', 'Percent encoded 1');"> percent encoded (opens in a new tab)</a>.
+Header data contents must be submitted using the US-ASCII character set, with other characters <a href="https://tools.ietf.org/html/rfc3986#section-2.1" target="_blank" rel="noopener noreferrer"> percent encoded (opens in a new tab)</a>.
 
-Each header has additional formatting requirements. To check a header format, you need to <a href="../connection-method/" onclick="ga('send', 'event', 'On Page Navigation', 'Connection Method', 'Select your connection method');">select your connection method</a>.
+Each header has additional formatting requirements. To check a header format, you need to <a href="../connection-method/">select your connection method</a>.
 
 
 ### Key-value encoding
@@ -61,7 +61,7 @@ Whenever a header contains a key-value data structure, you must use this format:
 
 Whenever a key is applicable but has no applicable value, you can omit the key-value pair or include the key with an empty value.
 
-Keys and values must be <a href="https://tools.ietf.org/html/rfc3986#section-2.1" target="_blank" rel="noopener noreferrer" onclick="ga('send', 'event', 'On Page Navigation', 'Key-value encoding', 'Percent encoded 2');"> percent encoded (opens in a new tab)</a>.
+Keys and values must be <a href="https://tools.ietf.org/html/rfc3986#section-2.1" target="_blank" rel="noopener noreferrer"> percent encoded (opens in a new tab)</a>.
 
 Key-value pairs can be submitted in any order.
 
@@ -72,7 +72,7 @@ Whenever a header contains a list, you must use this format:
 
 <code>&lt;value-1&gt;,&lt;value-2&gt;,&hellip;</code>
 
-Values must be <a href="https://tools.ietf.org/html/rfc3986#section-2.1" target="_blank" rel="noopener noreferrer" onclick="ga('send', 'event', 'On Page Navigation', 'List encoding', 'Percent encoded 3');"> percent encoded (opens in a new tab)</a>.
+Values must be <a href="https://tools.ietf.org/html/rfc3986#section-2.1" target="_blank" rel="noopener noreferrer"> percent encoded (opens in a new tab)</a>.
 
 Values must not be empty.
 
@@ -95,7 +95,7 @@ In exceptional cases you may be unable to collect a value due to restrictions be
 * security measures
 
 <div class="govuk-inset-text">
-If you are unable to submit a header, you must <a href="#contact-us" onclick="ga('send', 'event', 'On Page Navigation', 'Missing header data', 'Contact us');">contact us</a> to explain why. Make sure you include full details of the restrictions.
+If you are unable to submit a header, you must <a href="#contact-us">contact us</a> to explain why. Make sure you include full details of the restrictions.
 </div>
 
 After discussing a missing header with us, you can omit the header or submit it with an empty value. You must not include a placeholder value, for example <code>null</code> or <code>undefined</code>.
@@ -107,7 +107,7 @@ If you use or plan to use third-party software and libraries, make sure you can 
 
 ## Contact us
 <div class="extra-bottom-padding">
-You can send an email to <a href="mailto:SDSTeam@hmrc.gov.uk" onclick="ga('send', 'event', 'On Page Navigation', 'Contact us', 'SDST');">SDSTeam@hmrc.gov.uk</a>.
+You can send an email to <a href="mailto:SDSTeam@hmrc.gov.uk">SDSTeam@hmrc.gov.uk</a>.
 
 If you are explaining an exceptional case that means you cannot collect a value, include as many details as you can.
 </div>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -8,7 +8,7 @@ description: When you use some HMRC APIs, you’re legally required to submit da
 # Send fraud prevention data
 
 Version 3.1 issued 31 January 2022 <br/>
-<a href="change-log/" onclick="ga('send', 'event', 'On Page Navigation', 'Send fraud prevention data', 'Check what has changed');">Check what has changed</a>
+<a href="change-log/">Check what has changed</a>
 
 ## Why you must send data
 
@@ -21,22 +21,22 @@ When you use some of our APIs, you have to submit HTTP fraud prevention headers.
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
     You are required by law to submit header data for the
-    <a href="/api-documentation/docs/api/service/vat-api/1.0" onclick="ga('send', 'event', 'On Page Navigation', 'Why you must send data', 'VAT (MTD) API');">VAT (MTD)</a> and
-    <a href="/guides/income-tax-mtd-end-to-end-service-guide/" onclick="ga('send', 'event', 'On Page Navigation', 'Why you must send data', 'ITSA (MTD) API');">Income Tax Self Assessment (MTD)</a> APIs.
+    <a href="/api-documentation/docs/api/service/vat-api/1.0">VAT (MTD)</a> and
+    <a href="/guides/income-tax-mtd-end-to-end-service-guide/">Income Tax Self Assessment (MTD)</a> APIs.
     This includes all associated APIs and endpoints.
   </strong>
 </div>
 
-We work with you to help meet this specification. If after discussions with 
-HMRC an application continues to submit incorrect or missing data, software 
+We work with you to help meet this specification. If after discussions with
+HMRC an application continues to submit incorrect or missing data, software
 providers may be fined and blocked from using HMRC APIs.
-Check the <a href="Fraud%20Prevention%20Header%20Data%20Compliance%20and%20Sanctions%20Guidelines.pdf" onclick="ga('send', 'event', 'On Page Navigation', 'Why you must send data', 'Compliance and Sanctions Guidelines');">Compliance and Sanctions Guidelines (PDF)</a>.
+Check the <a href="Fraud%20Prevention%20Header%20Data%20Compliance%20and%20Sanctions%20Guidelines.pdf">Compliance and Sanctions Guidelines (PDF)</a>.
 
 
 ### Privacy and security
 
 HMRC has the right to collect audit data. We follow best practices set out by the Information Commissioner’s Office.
 
-Transaction monitoring is a key security approach used in the UK and globally. Our approach follows the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/271268/GPG_53_Transaction_Monitoring_issue_1-1_April_2013.pdf" onclick="ga('send', 'event', 'On Page Navigation', 'Privacy and security', 'Recommended guidance');">National Cyber Security Centre (NCSC) and the Cabinet Office’s recommended guidance (PDF)</a>.
+Transaction monitoring is a key security approach used in the UK and globally. Our approach follows the <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/271268/GPG_53_Transaction_Monitoring_issue_1-1_April_2013.pdf">National Cyber Security Centre (NCSC) and the Cabinet Office’s recommended guidance (PDF)</a>.
 
-For more information or to review your privacy notices, <a href="/api-documentation/assets/content/documentation/3f4c263faa8231bea05c1826b7f6b81c-TxM%20DPIA%20v3%201%20Public.pdf" onclick="ga('send', 'event', 'On Page Navigation', 'Privacy and security', 'Data protection impact assessment');">check the data protection impact assessment (PDF)</a>. You can also <a href="http://www.legislation.gov.uk/uksi/2019/360/made" onclick="ga('send', 'event', 'On Page Navigation', 'Privacy and security', 'Check the regulations');">check the regulations</a>.
+For more information or to review your privacy notices, <a href="/api-documentation/assets/content/documentation/3f4c263faa8231bea05c1826b7f6b81c-TxM%20DPIA%20v3%201%20Public.pdf">check the data protection impact assessment (PDF)</a>. You can also <a href="http://www.legislation.gov.uk/uksi/2019/360/made">check the regulations</a>.


### PR DESCRIPTION
Removes onclick attributes that use a deprecated Google Analytics API causing Javascript errors.