### PR TITLE
CMQ-2428: clarify responsibility for choosing correct tech stack

### DIFF
--- a/source/change-log/index.html.md.erb
+++ b/source/change-log/index.html.md.erb
@@ -7,14 +7,6 @@ description: Find out what has changed in the specification and make sure your a
 
 # Change log
 
-### Version 3.2
-
-#### 7 March 2023
-
- * Guidance on technology choices
-
-This will be updated in the Directions. To check what you need to send, <a href="../connection-method/">select your connection method</a>.
-
 ### Version 3.1
 
 #### 4 April 2022

--- a/source/change-log/index.html.md.erb
+++ b/source/change-log/index.html.md.erb
@@ -7,6 +7,14 @@ description: Find out what has changed in the specification and make sure your a
 
 # Change log
 
+### Version 3.2
+
+#### 7 March 2023
+
+ * Guidance on technology choices
+
+This will be updated in the Directions. To check what you need to send, <a href="../connection-method/">select your connection method</a>.
+
 ### Version 3.1
 
 #### 4 April 2022

--- a/source/connection-method/desktop-app-via-server/index.html.md.erb
+++ b/source/connection-method/desktop-app-via-server/index.html.md.erb
@@ -16,6 +16,8 @@ description: Check what data you need to submit if your application is installed
   </strong>
 </div>
 
+You should check that your chosen technology stack supports collecting data for all required headers, for example, [Gov-Client-Public-IP](#gov-client-public-ip) and [Gov-Client-Public-Port](#gov-client-public-port).
+
 Where multiple services manage your intermediary servers, headers must contain data from all services.
 
 <ol class="govuk-list cmq-header-list--numbered">

--- a/source/connection-method/index.html.md.erb
+++ b/source/connection-method/index.html.md.erb
@@ -9,6 +9,9 @@ description: The data you need to send depends on your software architecture. Se
 
 The header data you need to send depends on your software architecture. We refer to your architecture as a connection method.
 
+It is your responsibility to [choose the right technology stack](#choose-the-right-technology-stack) to support the collection of all header data required for your connection method.
+Some popular choices do not.
+
 Your connection method depends on <a href="#connecting-to-hmrc">how your application connects</a> to HMRC and your <a href="#originating-device">originating device</a>. You might have more than 1 connection method.
 
 To find out what data you need to send, select the connection methods used by your application.
@@ -52,6 +55,17 @@ Only select this for requests when your users do not initiate an action and your
   </div>
 </details>
 
+### Choose the right technology stack
+
+Before building your application, make sure you select technologies that will allow
+you to send all header data required for your connection method. For example, some popular load balancer
+products do not pass on users’ public IPs or ports.
+
+If you find out later that your chosen technology stack does not support sending all required values, it may
+involve effort to change.
+
+We are not able to provide advice on specific technologies.
+
 
 ### Connecting to HMRC
 
@@ -68,3 +82,4 @@ Originating device means the device that initiates an action, for example a VAT 
 In desktop application direct, or desktop application via server, the originating device might be a hosted desktop environment accessed remotely by the user.
 
 If actions initiated by users are stored on a server and sent in batches, the originating device is the user's device and not the server. You must only select batch process direct as a connection method when your users do not initiate an action.
+

--- a/source/connection-method/index.html.md.erb
+++ b/source/connection-method/index.html.md.erb
@@ -9,12 +9,12 @@ description: The data you need to send depends on your software architecture. Se
 
 The header data you need to send depends on your software architecture. We refer to your architecture as a connection method.
 
-It is your responsibility to [choose the right technology stack](#choose-the-right-technology-stack) to support the collection of all header data required for your connection method.
-Some popular choices do not.
-
 Your connection method depends on <a href="#connecting-to-hmrc">how your application connects</a> to HMRC and your <a href="#originating-device">originating device</a>. You might have more than 1 connection method.
 
 To find out what data you need to send, select the connection methods used by your application.
+
+It is your responsibility to [choose the right technology stack](#choose-the-right-technology-stack) to support the collection of all header data required for your connection method.
+Some popular ones do not.
 
 ## Select your connection method
 

--- a/source/connection-method/index.html.md.erb
+++ b/source/connection-method/index.html.md.erb
@@ -58,8 +58,8 @@ Only select this for requests when your users do not initiate an action and your
 ### Choose the right technology stack
 
 Before building your application, make sure you select technologies that will allow
-you to send all header data required for your connection method. For example, some popular load balancer
-products do not pass on users’ public IPs or ports.
+all header data required for your connection method to be sent. For example, some popular
+load balancers do not pass on users’ public IPs or ports.
 
 If you find out later that your chosen technology stack does not support sending all required values, it may
 involve effort to change.

--- a/source/connection-method/mobile-app-via-server/index.html.md.erb
+++ b/source/connection-method/mobile-app-via-server/index.html.md.erb
@@ -16,6 +16,8 @@ description: Check what data you need to submit if your application is installed
   </strong>
 </div>
 
+You should check that your chosen technology stack supports collecting data for all required headers, for example, [Gov-Client-Public-IP](#gov-client-public-ip) and [Gov-Client-Public-Port](#gov-client-public-port).
+
 Where multiple services manage your intermediary servers, headers must contain data from all services.
 
 <ol class="govuk-list cmq-header-list--numbered">

--- a/source/connection-method/other-via-server/index.html.md.erb
+++ b/source/connection-method/other-via-server/index.html.md.erb
@@ -16,6 +16,8 @@ description: Page description for search engines
   </strong>
 </div>
 
+You should check that your chosen technology stack supports collecting data for all required headers, for example, [Gov-Client-Public-IP](#gov-client-public-ip) and [Gov-Client-Public-Port](#gov-client-public-port).
+
 Where multiple services manage your intermediary servers, headers must contain data from all services.
 
 <ol class="govuk-list cmq-header-list--numbered">

--- a/source/connection-method/partials/gov-client-public-ip.erb
+++ b/source/connection-method/partials/gov-client-public-ip.erb
@@ -5,6 +5,8 @@
 
   <p>If the connection between client and server is over a private network, you will not be able to collect a value. You need to <a href="../../getting-it-right/#missing-header-data">check what to do about missing data</a>.</p>
 
+  <p>You should check that your chosen technology stack supports the collection of this value. Some popular load balancers do not.</p>
+
   <p><strong>Examples</strong></p>
 
   <pre><code>Gov-Client-Public-IP: 198.51.100.0</code></pre>

--- a/source/connection-method/partials/gov-client-public-port.erb
+++ b/source/connection-method/partials/gov-client-public-port.erb
@@ -3,6 +3,8 @@
 
   <p>The public TCP port used by the <a href="../#originating-device">originating device</a> when initiating the request.</p>
 
+  <p>You should check that your chosen technology stack supports the collection of this value. Some popular load balancers do not.</p>
+
   <ul class="govuk-list govuk-list--bullet">
     <li>This must not be a server port, for example 80 for http connections and 443 for https connections</li>
 

--- a/source/connection-method/web-app-via-server/index.html.md.erb
+++ b/source/connection-method/web-app-via-server/index.html.md.erb
@@ -16,6 +16,8 @@ description: Check what data you need to submit if your application is web based
   </strong>
 </div>
 
+You should check that your chosen technology stack supports collecting data for all required headers, for example, [Gov-Client-Public-IP](#gov-client-public-ip) and [Gov-Client-Public-Port](#gov-client-public-port).
+
 Where multiple services manage your intermediary servers, headers must contain data from all services.
 
 <ol class="govuk-list cmq-header-list--numbered">


### PR DESCRIPTION
* Avoided use of the word architecture as it is already used to describe connection method
* Added in three places: what you need to send, connection method and public IP and port sections