### PR TITLE
CMQ-2468 Revert library uplifts

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import play.sbt.PlayImport._
 import sbt._
 
 object AppDependencies {
-  val bootstrapVersion = "7.15.0"
+  val bootstrapVersion = "7.12.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.19")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")


### PR DESCRIPTION
What?
This PR reverts changes which uplifted some of the library versions used by the specification. These changes were introduced while upgrading to Scala 2.13.

Why?
When attempting to deploy the latest version to QA, multiple errors thrown by the `GuiceInjectorBuilder` indicated there were problems at boot time. 

After reverting these library uplifts the application is successfully deployed using Scala 2.13. 
Due to time constrains, it is not possible to investigate (as part of CMQ-2468) the reason why these library upgrades caused some injections to fail.
However, this should not stop us from upgrading to Scala 2.13, which is ultimately the requirement for CMQ-2468