### PR TITLE
CCIT-994: Fix govuk asset path when deployed to an environment

### DIFF
--- a/project/GenerateStaticHtmlFilesRunner.scala
+++ b/project/GenerateStaticHtmlFilesRunner.scala
@@ -32,7 +32,12 @@ object GenerateStaticHtmlFilesRunner extends AutoPlugin {
   override def projectSettings: Seq[Setting[?]] =
     Seq(
       generateFiles := {
+        val log = streams.value.log
+
+        log.info("Generating static site...")
         generateSite()
+
+        log.info("Rewriting asset paths...")
         rewriteAssetPaths()
       },
       (Compile / compile) := (Compile / compile).dependsOn(generateFiles).value

--- a/project/GenerateStaticHtmlFilesRunner.scala
+++ b/project/GenerateStaticHtmlFilesRunner.scala
@@ -34,6 +34,7 @@ object GenerateStaticHtmlFilesRunner extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[?]] =
     Seq(
+      generateFiles := rewriteAssetPaths.dependsOn(generateSite).value,
       generateSite := {
         streams.value.log.info("Generating static site...")
 
@@ -45,18 +46,16 @@ object GenerateStaticHtmlFilesRunner extends AutoPlugin {
         if (result != 0) sys.error("There was an error building the static site.")
       },
       rewriteAssetPaths := {
+        streams.value.log.info("Rewriting asset paths...")
+
         val filePath: String        = "public/stylesheets/manifest.css"
         val originalContent: String = readFileContent(filePath)
-
-        val log = streams.value.log
-        log.info("Rewriting asset paths...")
 
         updateFileContent(
           filePath,
           originalContent.replace("url(\"", "url(\"/guides/fraud-prevention")
         )
       },
-      generateFiles := rewriteAssetPaths.dependsOn(generateSite).value,
       (Compile / compile) := (Compile / compile).dependsOn(generateFiles).value
     )
 

--- a/project/GenerateStaticHtmlFilesRunner.scala
+++ b/project/GenerateStaticHtmlFilesRunner.scala
@@ -32,18 +32,16 @@ object GenerateStaticHtmlFilesRunner extends AutoPlugin {
   override def projectSettings: Seq[Setting[?]] =
     Seq(
       generateFiles := {
-        val log = streams.value.log
-
-        log.info("Generating static site...")
         generateSite()
 
-        log.info("Rewriting asset paths...")
         rewriteAssetPaths()
       },
       (Compile / compile) := (Compile / compile).dependsOn(generateFiles).value
     )
 
   def generateSite(): Unit = {
+    streams.value.log.info("Generating static site...")
+
     val result = ("bundle install" #&& Process(
       "bundle exec middleman build --build-dir=public/ --clean --verbose",
       None,
@@ -53,6 +51,8 @@ object GenerateStaticHtmlFilesRunner extends AutoPlugin {
   }
 
   private def rewriteAssetPaths(): Unit = {
+    streams.value.log.info("Rewriting asset paths...")
+
     val filePath: String        = "public/stylesheets/manifest.css"
     val originalContent: String = readFileContent(filePath)
 

--- a/project/GenerateStaticHtmlFilesRunner.scala
+++ b/project/GenerateStaticHtmlFilesRunner.scala
@@ -32,13 +32,13 @@ object GenerateStaticHtmlFilesRunner extends AutoPlugin {
   override def projectSettings: Seq[Setting[?]] =
     Seq(
       generateFiles := {
-        generateStatusFilesProcess()
+        generateSite()
         rewriteAssetPaths()
       },
       (Compile / compile) := (Compile / compile).dependsOn(generateFiles).value
     )
 
-  def generateStatusFilesProcess(): Unit = {
+  def generateSite(): Unit = {
     val result = ("bundle install" #&& Process(
       "bundle exec middleman build --build-dir=public/ --clean --verbose",
       None,

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,3 +1,5 @@
+$govuk-assets-path: "/guides/fraud-prevention/assets/govuk/assets/";
+
 @import "govuk_tech_docs";
 
 @import "govuk/components/button/button";

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,5 +1,3 @@
-$govuk-assets-path: "/guides/fraud-prevention/assets/govuk/assets/";
-
 @import "govuk_tech_docs";
 
 @import "govuk/components/button/button";

--- a/test/BuildSpec.scala
+++ b/test/BuildSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import java.io.File
+import scala.io.{BufferedSource, Source}
+
+class BuildSpec extends AnyWordSpec with Matchers {
+  "Building the content" should {
+    "rewrite font asset paths" in {
+      val filePath: String = "public/stylesheets/manifest.css"
+
+      val updatedContent: String = readFileContent(filePath)
+
+      updatedContent should include("url(\"/guides/fraud-prevention")
+    }
+  }
+
+  private def readFileContent(filePath: String): String = {
+    val file: File             = new File(filePath)
+    val source: BufferedSource = Source.fromFile(file, "UTF-8")
+    try source.getLines().mkString("\n")
+    finally source.close()
+  }
+}


### PR DESCRIPTION
## What?

* Re-instate previous method of re-writing font asset paths in `manifest.css` as used previously by BuildSpec.scala. This is consistent with the approach used in the following two service guides:
  * https://github.com/hmrc/self-assessment-end-to-end-service-guide/blob/main/test/BuildSpec.scala
  * https://github.com/hmrc/irr-api-end-to-end-service-guide/blob/main/test/BuildSpec.scala
* Re-instate BuildSpec.scala as a test to ensure asset paths are rewritten correctly. Previously this wasn't really a test, it was generating the site and had no meaningful assertions.
* Update the `generateFiles` task so it's dependent on compile that should ensure it runs before the tests, before the site is run locally, and before the app is packaged.
* Relies on https://github.com/hmrc/build-jobs/pull/18375

## Why?

* Without this the fonts are not loaded correctly.
* We are aiming to be consistent with other service guides.

## Testing

* This has been tested in QA: https://developer.qa.tax.service.gov.uk/guides/fraud-prevention/